### PR TITLE
Update sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,4 +20,4 @@ sonar.tests=tests
 # Properties specific to the C/C++ analyzer:
 sonar.cfamily.threads=2
 sonar.cfamily.build-wrapper-output=tests/build
-sonar.cfamily.gcov.reportsPath=tests/build
+sonar.cfamily.gcov.reportsPath=tests/build/CMakeFiles/**


### PR DESCRIPTION
Sonar-scanner seems not to be finding gcov reports.
Let's try to fix it.