### PR TITLE
Fix Sonarcloud path search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ matrix:
       sonarcloud:
         organization: "mualphaomegaepsilon-github"
     before_script: 
-    - cp "${LIBINTERCEPTOR_DIR}"/libinterceptor-x86_64.so "${LIBINTERCEPTOR_DIR}"/libinterceptor-haswell.so 
+    - LIBINTERCEPTOR = $(find -iname /home/travis/.sonar/cache/*/libinterceptor-x86_64.so)
+    - cp "${LIBINTERCEPTOR}"/libinterceptor-x86_64.so $(dirname "${LIBINTERCEPTOR_DIR}")/libinterceptor-haswell.so 
     after_script: cd ../.. && sonar-scanner > /dev/null
     
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ matrix:
       sonarcloud:
         organization: "mualphaomegaepsilon-github"
     before_script: 
+    - pushd .
     - LIBINTERCEPTOR=$(find /home/travis/.sonar/cache -name libinterceptor-x86_64.so)
     - cd $(dirname "${LIBINTERCEPTOR}")
-    - cp libinterceptor-x86_64.so libinterceptor-haswell.so 
+    - cp libinterceptor-x86_64.so libinterceptor-haswell.so
+    - popd
     after_script: cd ../.. && sonar-scanner > /dev/null
     
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ matrix:
       sonarcloud:
         organization: "mualphaomegaepsilon-github"
     before_script: 
-    - LIBINTERCEPTOR = $(find -iname /home/travis/.sonar/cache/*/libinterceptor-x86_64.so)
-    - cp "${LIBINTERCEPTOR}"/libinterceptor-x86_64.so $(dirname "${LIBINTERCEPTOR_DIR}")/libinterceptor-haswell.so 
+    - LIBINTERCEPTOR = $(find /home/travis/.sonar/cache -name libinterceptor-x86_64.so)
+    - cd $(dirname "${LIBINTERCEPTOR}")
+    - cp libinterceptor-x86_64.so libinterceptor-haswell.so 
     after_script: cd ../.. && sonar-scanner > /dev/null
     
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       sonarcloud:
         organization: "mualphaomegaepsilon-github"
     before_script: 
-    - LIBINTERCEPTOR = $(find /home/travis/.sonar/cache -name libinterceptor-x86_64.so)
+    - LIBINTERCEPTOR=$(find /home/travis/.sonar/cache -name libinterceptor-x86_64.so)
     - cd $(dirname "${LIBINTERCEPTOR}")
     - cp libinterceptor-x86_64.so libinterceptor-haswell.so 
     after_script: cd ../.. && sonar-scanner > /dev/null


### PR DESCRIPTION
Sonarcloud scanning broke due to a change in the cache folder where the dynamic library was located.
This PR adds a dynamic search for the path of libinterceptor.